### PR TITLE
Kafkafeat

### DIFF
--- a/simple/README.md
+++ b/simple/README.md
@@ -31,7 +31,7 @@ GOARCH=arm GOARM=7 GOOS=linux go build -o bacque-arm back/
 
 The app **front/craque** requires the environment variable `BACQUE` be set to the endpoint serving **back/bacque**.
 
-* In kubernetes (front.craque.yaml) this is set to `"http://bacque/fetch"`.
+* In kubernetes (front.craque.yaml) this is usually `"http://bacque:9999/fetch"`.
 * Running the go app directly, use `export BACQUE="http://localhost:9999/fetch"`.
 * With raw docker:
   * Start **bacque** first: `docker run --rm --name bacque -p 9999:9999 craque:Bv006`
@@ -47,7 +47,7 @@ RequestIP=192.168.192.65
 LocalIP=192.168.142.193
 ```
 
-Going to any invalid endpoint (e.g.: `/`, `/foo`, `/pickles`) will simply return "Hello. `/<endpoint>`"
+As of version Cv012, Craque will fall back to a local retrieval of DateTime if the endpoint set with BACQUE is unavailable (and returns with response code 418). It does *not* return the same "enriched sender/receiver IP data" that BACQUE does.
 
 ## Deploy to New Kubernetes Cluster (LoadBalancer service)
 
@@ -63,12 +63,11 @@ The last step requires AWS auth and a DNS zone already configured.
 
 ## Deploy to New Kubernetes Cluster (Istio)
 
-Similar to LB, except different configs are required.
+Similar to LB, except different configs are required. In this mode, Bacque does not have external access.
 
-1. Deploy backend ingress gw: `kubectl -n crq apply -f back/bacque-gw.yaml`
-2. Deploy backend: `kubectl -n crq apply -f back/bacque.yaml`
-3. Deploy frontend ingress gw: `kubectl -n crq apply -f front/craque-gw.yaml`
-4. Deploy frontend: `kubectl -n crq apply -f front/craque.yaml`
+1. Deploy backend: `kubectl -n crq apply -f back/bacque.yaml`
+2. Deploy frontend ingress gw: `kubectl -n crq apply -f front/craque-gw.yaml`
+3. Deploy frontend: `kubectl -n crq apply -f front/craque.yaml`
 
 ## Issues
 

--- a/simple/back/bacque.go
+++ b/simple/back/bacque.go
@@ -2,7 +2,6 @@
 
 	Bacque
 
-	/ - Hello
 	/fetch - returns three 'dynamic' actions:
 			- retrieves local timestamp from the container OS
 			- displays the client Request IP address
@@ -10,7 +9,13 @@
 	/ping - a readiness check
 	/metrics - prometheus metrics
 
-	Version = Bv011
+	Version = Bv012
+
+	Environment Variables
+
+	BACQUE_KAFKA = set to 'on' if kafka output is desired
+	BACQUE_KAFKA_BROKER = broker address
+	BACQUE_KAFKA_TOPIC = topic name
 
 */
 
@@ -111,7 +116,6 @@ func fetch(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// fmt.Printf("Created Producer %v\n", p)
 		log.Info().Msg("Created producer")
 
 		deliveryChan := make(chan kafka.Event)

--- a/simple/back/bacque.yaml
+++ b/simple/back/bacque.yaml
@@ -22,6 +22,13 @@ spec:
       containers:
       - name: bacque
         image: maroda/craque:Bv011
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "200m"
+          limits:
+            memory: "64Mi"
+            cpu: "250m"
         ports:
           - containerPort: 9999
         readinessProbe:

--- a/simple/cluster/README.md
+++ b/simple/cluster/README.md
@@ -1,6 +1,7 @@
 # Cluster General
 
-* craque-ns.yaml: creates the crq namespace
+* craque-ns.yaml: creates the crq namespace, with istio sidecar injection enabled.
+* istio-ns.yaml: creates istio-system namespace
 * CraqueBox-LONGNUMBER.json: Grafana dashboard for the application
 * CraqueGo-LONGNUMBER.json: Grafana dashboard for Go stats
 

--- a/simple/cluster/craque-ns.yaml
+++ b/simple/cluster/craque-ns.yaml
@@ -4,8 +4,3 @@ metadata:
   labels:
     istio-injection: enabled
   name: crq
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system

--- a/simple/cluster/istio-ns.yaml
+++ b/simple/cluster/istio-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system

--- a/simple/front/Dockerfile
+++ b/simple/front/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.11.5-alpine3.9
-LABEL version="011"
+LABEL version="012"
 LABEL vendor="Sounding"
 EXPOSE 8888
 WORKDIR /go/src/craque/

--- a/simple/front/alt/lb-craque.yaml
+++ b/simple/front/alt/lb-craque.yaml
@@ -1,23 +1,30 @@
 #
-# Simple Front-End using LoadBalancer
+# Simple Front-End using LoadBalancer #
 #
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: craque
+  name: craque-v012
+  labels:
+    app: craque
+    version: Cv012
 spec:
   replicas: 3
   template:
     metadata:
+      annotations:
+        sumologic.com/kubernetes_meta_reduce: "true"
+        sumologic.com/include: "true"
       labels:
         app: craque
+        version: Cv012
     spec:
       containers:
-      - name: craque-front
-        image: maroda/craque:Cv005
+      - name: craque
+        image: maroda/craque:Cv012
         env:
         - name: BACQUE
-          value: "http://bacque/fetch"
+          value: "http://bacque:9999/fetch"
         ports:
           - containerPort: 8888
         readinessProbe:
@@ -34,7 +41,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "8888"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"
   name: craque
+  labels:
+    app: craque
+    service: craque
 spec:
   type: LoadBalancer
   selector:

--- a/simple/front/craque.yaml
+++ b/simple/front/craque.yaml
@@ -4,10 +4,10 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: craque-v011
+  name: craque-v012
   labels:
     app: craque
-    version: Cv011
+    version: Cv012
 spec:
   replicas: 3
   template:
@@ -17,11 +17,11 @@ spec:
         sumologic.com/include: "true"
       labels:
         app: craque
-        version: Cv011
+        version: Cv012
     spec:
       containers:
       - name: craque
-        image: maroda/craque:Cv011
+        image: maroda/craque:Cv012
         env:
         - name: BACQUE
           value: "http://bacque:9999/fetch"

--- a/simple/nada/inque.go
+++ b/simple/nada/inque.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"net/http"
+	"os"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 type intHandle struct{}
@@ -17,9 +21,95 @@ func (h intHandle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, f := range l {
 		fmt.Fprintf(w, "int: %s\n", f.Name)
 	}
+
+	zerolog.TimeFieldFormat = ""
+	log.Info().
+		Str("host", r.Host).
+		Str("ref", r.RemoteAddr).
+		Str("xref", r.Header.Get("X-Forwarded-For")).
+		Str("method", r.Method).
+		Str("path", r.URL.Path).
+		Str("proto", r.Proto).
+		Str("agent", r.Header.Get("User-Agent")).
+		Str("response", "200").
+		Msg("")
+}
+
+// Spin up a consumer if feature is set
+func consumeK() {
+
+	featK := os.Getenv("BACQUE_KAFKA")
+
+	if featK == "on" {
+
+		broker := os.Getenv("BACQUE_KAFKA_BROKER")
+		group := os.Getenv("BACQUE_KAFKA_GROUP")
+
+		// this isn't working yet
+		// it's accepting the slice,
+		// but the consumer is getting empty events
+		var topics []string
+		for _, n := range os.Getenv("BACQUE_KAFKA_TOPIC") {
+			topics = append(topics, string(n))
+		}
+		log.Info().Str("topics", topics[0])
+
+		c, err := kafka.NewConsumer(&kafka.ConfigMap{
+			"bootstrap.servers":     broker,
+			"broker.address.family": "v4", // avoids v6 broker resolution on OSX
+			"group.id":              group,
+			"session.timeout.ms":    6000,
+			"auto.offset.reset":     "earliest"})
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to create consumer!")
+			return
+		}
+
+		log.Info().Msg("Created consumer")
+
+		err = c.SubscribeTopics(topics, nil)
+
+		run := true
+
+		for run == true {
+			select {
+			default:
+				ev := c.Poll(100)
+				if ev == nil {
+					// log.Debug().Msg("ev is nil")
+					continue
+				}
+
+				// either the topic is wrong
+				// or the consumer isn't working
+				// because it's not getting this far
+
+				switch e := ev.(type) {
+				case *kafka.Message:
+					log.Info().
+						Str("Value", string(e.Value)).
+						Msg("")
+				case kafka.Error:
+					log.Info().
+						Str("error", string(e.Code())).
+						Msg("Broker Error")
+				default:
+					log.Warn().Msg("Ignored event")
+				}
+			}
+		}
+
+		log.Info().Msg("Closing consumer")
+		c.Close()
+	}
 }
 
 func main() {
+
+	go consumeK()
+
 	err := http.ListenAndServe(":7777", intHandle{})
-	log.Fatal(err)
+	if err != nil {
+		log.Fatal()
+	}
 }


### PR DESCRIPTION
- Kafka Producer is now a feature flag in Bacque (Bv012), not pushed to hub.docker.com yet, so the "deployed" version is still Bv011.
- Inque has Kafka Consumer as a feature flag, but the topic assignment is currently broken.
- Craque has been modified to use a "fallback" if Bacque isn't available (Cv012), and that *has* been pushed to hub.docker.com.

Bacque and Craque have been tested and working in prod kube cluster.