### PR TITLE
v12 for resource limits but no kafka, DNS with tf

### DIFF
--- a/simple/back/Dockerfile
+++ b/simple/back/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.11.5-alpine3.9
-LABEL version="011"
+LABEL version="012"
 LABEL vendor="Sounding"
 EXPOSE 9999
 WORKDIR /go/src/bacque/

--- a/simple/demo/bacque.yaml
+++ b/simple/demo/bacque.yaml
@@ -1,5 +1,5 @@
 #
-# Simple Back-End using Istio
+# Simple Back-End using ClusterIP
 #
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -9,7 +9,7 @@ metadata:
     app: bacque
     version: Bv012
 spec:
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       annotations:

--- a/simple/demo/craque-ns.yaml
+++ b/simple/demo/craque-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crq

--- a/simple/demo/lb-craque.yaml
+++ b/simple/demo/lb-craque.yaml
@@ -1,27 +1,27 @@
 #
-# Simple Back-End using Istio
+# Simple Front-End using LoadBalancer
 #
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: bacque-v012
+  name: craque-v012
   labels:
-    app: bacque
-    version: Bv012
+    app: craque
+    version: Cv012
 spec:
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       annotations:
         sumologic.com/kubernetes_meta_reduce: "true"
         sumologic.com/include: "true"
       labels:
-        app: bacque
-        version: Bv012
+        app: craque
+        version: Cv012
     spec:
       containers:
-      - name: bacque
-        image: maroda/craque:Bv012
+      - name: craque
+        image: maroda/craque:Cv012
         resources:
           requests:
             memory: "32Mi"
@@ -29,12 +29,15 @@ spec:
           limits:
             memory: "64Mi"
             cpu: "250m"
+        env:
+        - name: BACQUE
+          value: "http://bacque:9999/fetch"
         ports:
-          - containerPort: 9999
+          - containerPort: 8888
         readinessProbe:
           httpGet:
             path: /ping
-            port: 9999
+            port: 8888
           periodSeconds: 2
           initialDelaySeconds: 0
           failureThreshold: 3
@@ -46,16 +49,18 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    prometheus.io/port: "9999"
+    prometheus.io/port: "8888"
     prometheus.io/scheme: http
     prometheus.io/scrape: "true"
-  name: bacque
+  name: craque
   labels:
-    app: bacque
-    service: bacque
+    app: craque
+    service: craque
 spec:
+  type: LoadBalancer
   selector:
-    app: bacque
+    app: craque
   ports:
-  - port: 9999
-    name: http
+  - protocol: TCP
+    port: 80
+    targetPort: 8888

--- a/simple/front/alt/lb-craque.yaml
+++ b/simple/front/alt/lb-craque.yaml
@@ -22,6 +22,13 @@ spec:
       containers:
       - name: craque
         image: maroda/craque:Cv012
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "200m"
+          limits:
+            memory: "64Mi"
+            cpu: "250m"
         env:
         - name: BACQUE
           value: "http://bacque:9999/fetch"

--- a/simple/front/craque.yaml
+++ b/simple/front/craque.yaml
@@ -22,6 +22,13 @@ spec:
       containers:
       - name: craque
         image: maroda/craque:Cv012
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "200m"
+          limits:
+            memory: "64Mi"
+            cpu: "250m"
         env:
         - name: BACQUE
           value: "http://bacque:9999/fetch"

--- a/simple/front/tf/dns.tf
+++ b/simple/front/tf/dns.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "app" {
+  zone_id = "${var.zoneid}"
+  name    = "app.${var.zoneapex}"
+  type    = "CNAME"
+  ttl     = 60
+  records = ["${var.simple_lb}"]
+}

--- a/simple/front/tf/tf.auto.tfvars
+++ b/simple/front/tf/tf.auto.tfvars
@@ -1,0 +1,3 @@
+aws_region = "us-west-2"
+zoneapex = "craq.io"
+zoneid = "Z774WO4JZLFEM"

--- a/simple/front/tf/vars.tf
+++ b/simple/front/tf/vars.tf
@@ -1,0 +1,4 @@
+variable "aws_region" {}
+variable "simple_lb" {}
+variable "zoneapex" {}
+variable "zoneid" {}


### PR DESCRIPTION
The Kafka feature is added to the Go code, but doesn't work in a container yet. For v12, it's been commented out. This is the version used in the QCon Workshop on 6/28.